### PR TITLE
Add settings menu with persistent API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ poetry run flet run --web
 
 For more details on running the app, refer to the [Getting Started Guide](https://flet.dev/docs/getting-started/).
 
+When the app is running use the menu button in the top bar to open **Settings** and
+provide your API key. The key is stored locally so you don't have to re-enter it
+next time.
+
 ## Build the app
 
 ### Android
@@ -91,11 +95,12 @@ I wrote this app to learn more about Flet and LLM. Its basically  a chat app tha
 - Uses Flet for the UI
 - Uses Koboldcpp for the LLM
 - Context chat aware
+- Settings menu to store your API key
 
 ## Todos
 - [x] Bring in last messages as context
 - [ ] Markdown rendering
-- [ ] Settings menu to set LLM API
+- [x] Settings menu to set LLM API
 - [ ] Make messages editable
 - [ ] Let LLM regenerate last message
 - [ ] make it more beautiful

--- a/src/backend.py
+++ b/src/backend.py
@@ -1,5 +1,6 @@
 import json
 import requests
+from typing import Optional
 
 
 class ChatBackend:
@@ -7,11 +8,15 @@ class ChatBackend:
 
     DEFAULT_SYSTEM_PROMPT = "Du bist ein hilfreicher Assistent."
 
-    def __init__(self, api_url: str):
+    def __init__(self, api_url: str, api_key: str = ""):
         self.api_url = api_url
+        self.api_key = api_key
         self.chat_history = [
             {"role": "system", "content": self.DEFAULT_SYSTEM_PROMPT}
         ]
+
+    def set_api_key(self, api_key: str) -> None:
+        self.api_key = api_key
 
     def add_user_message(self, text: str) -> None:
         self.chat_history.append({"role": "user", "content": text})
@@ -22,6 +27,9 @@ class ChatBackend:
     def generate_reply(self, max_tokens: int = 200, temperature: float = 0.8) -> str:
         """Generate a reply using the entire chat history."""
         try:
+            headers = {}
+            if self.api_key:
+                headers["Authorization"] = f"Bearer {self.api_key}"
             response = requests.post(
                 self.api_url,
                 json={
@@ -31,6 +39,7 @@ class ChatBackend:
                     "temperature": temperature,
                     "stream": True,
                 },
+                headers=headers,
                 timeout=120,
                 stream=True,
             )

--- a/src/main.py
+++ b/src/main.py
@@ -2,15 +2,18 @@ import flet as ft
 
 from backend import ChatBackend
 from frontend_flet import FletChatApp
+from settings import SettingsManager
 
 # KOBOLDCPP_API_URL = "http://localhost:5001/v1/chat/completions"
 KOBOLDCPP_API_URL = "http://home:5001/v1/chat/completions"
 
-backend = ChatBackend(KOBOLDCPP_API_URL)
+settings_manager = SettingsManager()
+app_settings = settings_manager.load()
+backend = ChatBackend(KOBOLDCPP_API_URL, api_key=app_settings.api_key)
 
 
 def main(page: ft.Page):
-    app = FletChatApp(backend)
+    app = FletChatApp(backend, settings_manager, app_settings)
     app.build(page)
 
 

--- a/src/settings.py
+++ b/src/settings.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass, asdict
+import json
+from typing import Any
+
+
+@dataclass
+class Settings:
+    api_key: str = ""
+
+
+class SettingsManager:
+    """Load and save application settings."""
+
+    def __init__(self, path: str = "settings.json") -> None:
+        self.path = path
+
+    def load(self) -> Settings:
+        try:
+            with open(self.path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            return Settings(**data)
+        except FileNotFoundError:
+            return Settings()
+        except Exception:
+            return Settings()
+
+    def save(self, settings: Settings) -> None:
+        with open(self.path, "w", encoding="utf-8") as f:
+            json.dump(asdict(settings), f, indent=2)
+


### PR DESCRIPTION
## Summary
- add persistent settings manager
- store API key in settings and use it in backend requests
- add navigation drawer with Settings dialog to set the API key
- load settings on startup
- update README with instructions and completed todo

## Testing
- `python -m py_compile src/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68447d0ca804832099f034847c446d86