### PR TITLE
Add settings page and navigation drawer

### DIFF
--- a/src/backend.py
+++ b/src/backend.py
@@ -13,6 +13,10 @@ class ChatBackend:
             {"role": "system", "content": self.DEFAULT_SYSTEM_PROMPT}
         ]
 
+    def set_api_url(self, url: str) -> None:
+        """Update the KoboldCPP API endpoint."""
+        self.api_url = url
+
     def add_user_message(self, text: str) -> None:
         self.chat_history.append({"role": "user", "content": text})
 

--- a/src/frontend_flet.py
+++ b/src/frontend_flet.py
@@ -47,113 +47,184 @@ class FletChatApp:
         page.horizontal_alignment = ft.CrossAxisAlignment.STRETCH
         page.title = "Flet + KoboldCPP: Voller Chatkontext"
 
-        join_user_name = ft.TextField(
-            label="Enter your name to join the chat",
-            autofocus=True,
-            on_submit=lambda e: join_chat_click(e),
-        )
-        welcome_dlg = ft.AlertDialog(
-            open=True,
-            modal=True,
-            title=ft.Text("Welcome!"),
-            content=ft.Column([join_user_name], width=300, height=70, tight=True),
-            actions=[ft.ElevatedButton(text="Join chat", on_click=lambda e: join_chat_click(e))],
-            actions_alignment=ft.MainAxisAlignment.END,
-        )
-        page.overlay.append(welcome_dlg)
+        # AppBar and drawer -------------------------------------------------
+        def open_drawer(e):
+            page.drawer.open = True
+            page.drawer.update()
 
-        chat = ft.ListView(expand=True, spacing=10, auto_scroll=True)
-        new_message = ft.TextField(
-            hint_text="Write a message...",
-            autofocus=True,
-            shift_enter=True,
-            min_lines=1,
-            max_lines=5,
-            filled=True,
-            expand=True,
-            on_submit=lambda e: send_message_click(e),
+        page.appbar = ft.AppBar(
+            leading=ft.IconButton(ft.Icons.MENU, on_click=open_drawer),
+            title=ft.Text("Flet Chat"),
         )
 
-        def join_chat_click(e):
-            if not join_user_name.value:
-                join_user_name.error_text = "Name cannot be blank!"
-                join_user_name.update()
-                return
+        def on_drawer_change(e):
+            if page.drawer.selected_index == 0:
+                page.go("/")
+            elif page.drawer.selected_index == 1:
+                page.go("/settings")
 
-            page.session.set("user_name", join_user_name.value)
-            welcome_dlg.open = False
-            new_message.prefix = ft.Text(f"{join_user_name.value}: ")
-            page.pubsub.send_all(
-                Message(
-                    user_name=join_user_name.value,
-                    text=f"{join_user_name.value} has joined the chat.",
-                    message_type="login_message",
-                )
-            )
-            page.update()
+        page.drawer = ft.NavigationDrawer(
+            controls=[
+                ft.NavigationDrawerDestination(
+                    icon=ft.icons.CHAT, label="Chat"
+                ),
+                ft.NavigationDrawerDestination(
+                    icon=ft.icons.SETTINGS, label="Settings"
+                ),
+            ],
+            on_change=on_drawer_change,
+            selected_index=0,
+        )
 
-        def send_message_click(e):
-            text = new_message.value.strip()
-            if not text:
-                return
+        # ------------------------- Views ------------------------------------
 
-            user_name = page.session.get("user_name") or "Unknown"
-
-            page.pubsub.send_all(
-                Message(
-                    user_name=user_name,
-                    text=text,
-                    message_type="chat_message",
-                )
+        def build_chat_view() -> ft.View:
+            join_user_name = ft.TextField(
+                label="Enter your name to join the chat",
+                autofocus=True,
+                on_submit=lambda e: join_chat_click(e),
             )
 
-            self.backend.add_user_message(text)
-
-            new_message.value = ""
-            new_message.focus()
-            page.update()
-
-            bot_reply = self.backend.generate_reply()
-            self.backend.add_assistant_message(bot_reply)
-
-            page.pubsub.send_all(
-                Message(
-                    user_name="Bot",
-                    text=bot_reply,
-                    message_type="chat_message",
-                )
+            welcome_dlg = ft.AlertDialog(
+                open=True,
+                modal=True,
+                title=ft.Text("Welcome!"),
+                content=ft.Column([join_user_name], width=300, height=70, tight=True),
+                actions=[ft.ElevatedButton(text="Join chat", on_click=lambda e: join_chat_click(e))],
+                actions_alignment=ft.MainAxisAlignment.END,
             )
-            page.update()
 
-        def on_message(message: Message):
-            if message.message_type == "chat_message":
-                m = ChatMessage(message)
-            elif message.message_type == "login_message":
-                m = ft.Text(message.text, italic=True, color=ft.Colors.BLACK45, size=12)
-            else:
-                return
+            page.overlay.clear()
+            page.overlay.append(welcome_dlg)
 
-            chat.controls.append(m)
-            page.update()
+            chat = ft.ListView(expand=True, spacing=10, auto_scroll=True)
 
-        page.pubsub.subscribe(on_message)
-
-        page.add(
-            ft.Container(
-                content=chat,
-                border=ft.border.all(1, ft.Colors.OUTLINE),
-                border_radius=5,
-                padding=10,
+            new_message = ft.TextField(
+                hint_text="Write a message...",
+                autofocus=True,
+                shift_enter=True,
+                min_lines=1,
+                max_lines=5,
+                filled=True,
                 expand=True,
-            ),
-            ft.Row(
+                on_submit=lambda e: send_message_click(e),
+            )
+
+            def join_chat_click(e):
+                if not join_user_name.value:
+                    join_user_name.error_text = "Name cannot be blank!"
+                    join_user_name.update()
+                    return
+
+                page.session.set("user_name", join_user_name.value)
+                welcome_dlg.open = False
+                new_message.prefix = ft.Text(f"{join_user_name.value}: ")
+                page.pubsub.send_all(
+                    Message(
+                        user_name=join_user_name.value,
+                        text=f"{join_user_name.value} has joined the chat.",
+                        message_type="login_message",
+                    )
+                )
+                page.update()
+
+            def send_message_click(e):
+                text = new_message.value.strip()
+                if not text:
+                    return
+
+                user_name = page.session.get("user_name") or "Unknown"
+
+                page.pubsub.send_all(
+                    Message(
+                        user_name=user_name,
+                        text=text,
+                        message_type="chat_message",
+                    )
+                )
+
+                self.backend.add_user_message(text)
+
+                new_message.value = ""
+                new_message.focus()
+                page.update()
+
+                bot_reply = self.backend.generate_reply()
+                self.backend.add_assistant_message(bot_reply)
+
+                page.pubsub.send_all(
+                    Message(
+                        user_name="Bot",
+                        text=bot_reply,
+                        message_type="chat_message",
+                    )
+                )
+                page.update()
+
+            def on_message(message: Message):
+                if message.message_type == "chat_message":
+                    m = ChatMessage(message)
+                elif message.message_type == "login_message":
+                    m = ft.Text(message.text, italic=True, color=ft.Colors.BLACK45, size=12)
+                else:
+                    return
+
+                chat.controls.append(m)
+                page.update()
+
+            if not getattr(page, "chat_subscribed", False):
+                page.pubsub.subscribe(on_message)
+                page.chat_subscribed = True
+
+            content = ft.Column(
                 [
-                    new_message,
-                    ft.IconButton(
-                        icon=ft.Icons.SEND_ROUNDED,
-                        tooltip="Send message",
-                        on_click=lambda e: send_message_click(e),
+                    ft.Container(
+                        content=chat,
+                        border=ft.border.all(1, ft.Colors.OUTLINE),
+                        border_radius=5,
+                        padding=10,
+                        expand=True,
                     ),
-                ]
-            ),
-        )
+                    ft.Row(
+                        [
+                            new_message,
+                            ft.IconButton(
+                                icon=ft.Icons.SEND_ROUNDED,
+                                tooltip="Send message",
+                                on_click=lambda e: send_message_click(e),
+                            ),
+                        ]
+                    ),
+                ],
+                expand=True,
+            )
+
+            return ft.View(route="/", controls=[content], appbar=page.appbar, drawer=page.drawer)
+
+        def build_settings_view() -> ft.View:
+            api_url = ft.TextField(label="KoboldCPP URL", value=self.backend.api_url, expand=True)
+            info = ft.Text()
+
+            def save_click(e):
+                self.backend.set_api_url(api_url.value)
+                info.value = "Settings saved"
+                page.update()
+
+            content = ft.Column([
+                api_url,
+                ft.ElevatedButton("Save", on_click=save_click),
+                info,
+            ], expand=True)
+
+            return ft.View(route="/settings", controls=[content], appbar=page.appbar, drawer=page.drawer)
+
+        def route_change(e):
+            page.views.clear()
+            if page.route == "/settings":
+                page.views.append(build_settings_view())
+            else:
+                page.views.append(build_chat_view())
+            page.update()
+
+        page.on_route_change = route_change
+        page.go(page.route)


### PR DESCRIPTION
## Summary
- enable ChatBackend api url updates via `set_api_url`
- add navigation drawer with Chat and Settings options
- implement settings page with field to modify KoboldCPP URL
- refactor chat UI to work with view based routing

## Testing
- `python -m py_compile src/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6845b7b0a9e083208c556c4b72666588