### PR TITLE
Add agent instructions and tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# Instructions for Codex Agents
+
+This repository hosts a small Flet based chat client that talks to a KoboldCPP server.
+All application code lives inside the `src/` directory. Backend modules contain
+logic and data handling while UI components live under `frontend/`.
+
+## Coding Conventions
+- Use 4 spaces per indentation level.
+- Keep imports alphabetically sorted within each section.
+- Provide type hints and descriptive docstrings for new functions.
+- Backend and frontend code should remain separated as in the current structure.
+
+## Setup
+- Python 3.11 or newer is required.
+- Install dependencies with:
+  ```bash
+  pip install -e .[dev]
+  ```
+  The `[dev]` extra installs testing requirements.
+- Run the application with `flet run` once dependencies are installed.
+
+## Testing
+- Tests are located in the `tests/` directory and use **pytest**.
+- Execute the tests with:
+  ```bash
+  python -m pytest
+  ```
+- Tests must not read or write the real `settings.json` or `diary_entries.json`.
+  Use `tmp_path` or other temporary locations when working with those files.
+- All code changes should be covered by unit tests when feasible.
+
+## Pull Requests
+- Ensure the test suite passes before committing.
+- Include concise commit messages and avoid large unrelated changes.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,17 @@ packages:
 Execution begins in `main.py` which creates the backend and loads settings
 before handing control to Flet.
 
+## Development
+
+Development guidelines and testing instructions are described in
+[`AGENTS.md`](AGENTS.md). To run the unit tests yourself install the project with
+the optional development dependencies and execute:
+
+```bash
+pip install -e .[dev]
+python -m pytest
+```
+
 ## TODO
 
 

--- a/tests/test_chat_message.py
+++ b/tests/test_chat_message.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))
+
+from frontend.chat_message import ChatMessage
+
+
+def test_get_initials():
+    assert ChatMessage._get_initials('Bob') == 'B'
+    assert ChatMessage._get_initials('') == '?'
+
+
+def test_avatar_color_deterministic():
+    assert ChatMessage._get_avatar_color('Alice') == ChatMessage._get_avatar_color('Alice')

--- a/tests/test_diary.py
+++ b/tests/test_diary.py
@@ -1,0 +1,16 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))
+
+from backend import add_entry, load_entries, DiaryEntry
+
+
+def test_add_and_load_entries(tmp_path):
+    path = tmp_path / 'diary.json'
+    entry = add_entry('hello', path)
+    assert entry.text == 'hello'
+    assert isinstance(entry.timestamp, str)
+
+    entries = load_entries(path)
+    assert isinstance(entries[-1], DiaryEntry)
+    assert entries[-1].text == 'hello'

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))
+
+from backend import AppSettings, load_settings, save_settings
+
+
+def test_load_settings_defaults(tmp_path):
+    path = tmp_path / 'settings.json'
+    settings = load_settings(path)
+    assert isinstance(settings, AppSettings)
+    assert settings.api_url == "http://localhost:5001/v1/chat/completions"
+
+
+def test_save_and_load_settings(tmp_path):
+    path = tmp_path / 'settings.json'
+    settings = AppSettings(api_url='http://example.com')
+    save_settings(settings, path)
+    loaded = load_settings(path)
+    assert loaded == settings


### PR DESCRIPTION
## Summary
- document repository conventions in AGENTS.md
- show how to run the test suite in README
- add unit tests for settings, diary entries and chat messages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849b02de1ac83209667998a825124d5