### PR TITLE
Improve connection error handling

### DIFF
--- a/src/backend/__init__.py
+++ b/src/backend/__init__.py
@@ -1,10 +1,11 @@
-from .backend import ChatBackend
+from .backend import ChatBackend, ChatConnectionError
 from .models import Message
 from .settings_manager import AppSettings, load_settings, save_settings
 from .diary_manager import DiaryEntry, add_entry, load_entries
 
 __all__ = [
     "ChatBackend",
+    "ChatConnectionError",
     "Message",
     "AppSettings",
     "load_settings",

--- a/src/frontend/app.py
+++ b/src/frontend/app.py
@@ -2,6 +2,7 @@ import flet as ft
 
 from backend import (
     ChatBackend,
+    ChatConnectionError,
     Message,
     AppSettings,
     save_settings,
@@ -91,7 +92,12 @@ class FletChatApp:
             chat_view.new_message.focus()
             page.update()
 
-            bot_reply = self.backend.generate_reply()
+            try:
+                bot_reply = self.backend.generate_reply()
+            except ChatConnectionError as ex:
+                chat_view.show_error(str(ex))
+                return
+
             self.backend.add_assistant_message(bot_reply)
 
             page.pubsub.send_all(Message(user_name="Bot", text=bot_reply, message_type="chat_message"))

--- a/src/frontend/chat_message.py
+++ b/src/frontend/chat_message.py
@@ -8,7 +8,7 @@ class ChatMessage(ft.Row):
 
     def __init__(self, message: Message):
         """Create visual representation of a message for the chat list."""
-        super().__init__()
+        super().__init__(expand=True)
         self.vertical_alignment = ft.CrossAxisAlignment.START
         self.controls = [
             ft.CircleAvatar(
@@ -22,6 +22,7 @@ class ChatMessage(ft.Row):
                     ft.Text(message.text, selectable=True),
                 ],
                 tight=True,
+                expand=True,
                 spacing=5,
             ),
         ]

--- a/src/frontend/chat_view.py
+++ b/src/frontend/chat_view.py
@@ -1,3 +1,4 @@
+import asyncio
 import flet as ft
 
 from backend import ChatBackend, Message
@@ -11,6 +12,7 @@ class ChatView(ft.Column):
     def __init__(self, backend: ChatBackend, send_message_callback):
         """Initialize widgets and wire up the send message callback."""
         self.backend = backend
+        self.error_banner = ft.Banner(bgcolor=ft.Colors.RED_300, content=ft.Text(""), actions=[])
         self.chat = ft.ListView(expand=True, spacing=10, auto_scroll=True)
         self.new_message = ft.TextField(
             hint_text="Write a message...",
@@ -45,6 +47,20 @@ class ChatView(ft.Column):
             expand=True,
             visible=True,
         )
+
+    def show_error(self, text: str) -> None:
+        """Display a temporary error banner at the top of the page."""
+        if not self.page:
+            return
+        self.error_banner.content = ft.Text(text, color=ft.Colors.WHITE)
+        self.page.banner = self.error_banner
+        self.page.open(self.error_banner)
+        self.page.run_task(self._close_banner)
+
+    async def _close_banner(self):
+        await asyncio.sleep(3)
+        if self.page:
+            self.page.close(self.error_banner)
 
     def set_user(self, user_name: str) -> None:
         """Update message prefix with the current user name."""

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,0 +1,17 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))
+
+import requests
+from backend import ChatBackend
+
+
+def test_generate_reply_connection_error(monkeypatch):
+    def fake_post(*args, **kwargs):
+        raise requests.ConnectionError("boom")
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    backend = ChatBackend("http://invalid")
+    backend.add_user_message("hi")
+    reply = backend.generate_reply()
+    assert "error connecting" in reply

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -3,7 +3,8 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))
 
 import requests
-from backend import ChatBackend
+import pytest
+from backend import ChatBackend, ChatConnectionError
 
 
 def test_generate_reply_connection_error(monkeypatch):
@@ -13,5 +14,5 @@ def test_generate_reply_connection_error(monkeypatch):
     monkeypatch.setattr(requests, "post", fake_post)
     backend = ChatBackend("http://invalid")
     backend.add_user_message("hi")
-    reply = backend.generate_reply()
-    assert "error connecting" in reply
+    with pytest.raises(ChatConnectionError):
+        backend.generate_reply()

--- a/tests/test_chat_message.py
+++ b/tests/test_chat_message.py
@@ -3,6 +3,7 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))
 
 from frontend.chat_message import ChatMessage
+from backend import Message
 
 
 def test_get_initials():
@@ -12,3 +13,12 @@ def test_get_initials():
 
 def test_avatar_color_deterministic():
     assert ChatMessage._get_avatar_color('Alice') == ChatMessage._get_avatar_color('Alice')
+
+
+def test_message_expands_to_width():
+    msg = ChatMessage(Message(user_name="Bob", text="Hello", message_type="chat_message"))
+    # Row should expand to fill parent width for wrapping
+    assert msg.expand is True
+    # Column containing the text should also expand
+    column = msg.controls[1]
+    assert column.expand is True

--- a/tests/test_chat_view.py
+++ b/tests/test_chat_view.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))
+
+from frontend.chat_view import ChatView
+from backend import ChatBackend
+
+class DummyPage:
+    def __init__(self):
+        self.banner = None
+        self.open_called = False
+        self.task = None
+    def open(self, banner):
+        self.banner = banner
+        self.open_called = True
+    def close(self, banner):
+        self.banner = None
+    def run_task(self, coro):
+        self.task = coro
+
+def test_show_error_opens_banner():
+    view = ChatView(ChatBackend("http://invalid"), lambda e: None)
+    dummy = DummyPage()
+    view.page = dummy
+    view.show_error("boom")
+    assert dummy.banner is view.error_banner
+    assert dummy.open_called
+    assert dummy.task is not None
+    assert view.error_banner.content.value == "boom"


### PR DESCRIPTION
## Summary
- return connection error earlier by shrinking timeout and catching errors during streaming
- add regression test for request failure

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c42d0f8a08320b6cc0735846d84a7