### PR TITLE
Add LangMem docs references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,5 +35,5 @@ logic and data handling while UI components live under `frontend/`.
 
 ## Documentation
 Offline Flet documentation resides in `docs/flet-docs`.
-Place any Langchain-related docs under `docs/langchain-docs`.
+Place any Langchain-related docs under `docs/langchain-docs`. The repository already includes documentation for `LangMem`.
 Update the Flet docs whenever the `flet` dependency version changes.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ python -m pytest
 
 ## Documentation
 
-Offline documentation for Flet lives under `docs/flet-docs` and can be consulted without internet access. An empty `docs/langchain-docs` directory exists for future Langchain documentation.
+Offline documentation for Flet lives under `docs/flet-docs` and can be consulted without internet access. Langchain documentation resides under `docs/langchain-docs` and currently includes the `LangMem` module.
 
 ## TODO
 
@@ -81,7 +81,7 @@ Offline documentation for Flet lives under `docs/flet-docs` and can be consulted
   - [ ] Make past messages of LLM or user editable
   - [ ] Let LLM regenerate last message
   - [ ] Save chat 
-  - [ ] Long term memory via Langchain
+  - [ ] Long term memory via Langchain (`LangMem`)
   - [ ] fix streaming messages, despite ```"stream": True``` in backend.py it does not work
   - [ ] Markdown rendering
 


### PR DESCRIPTION
## Summary
- mention LangMem docs under `docs/langchain-docs`
- clarify TODO item about long-term memory
- update agent instructions to reference LangMem docs

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_684d7adaad7c832094972c8c4bb306ac