### PR TITLE
Add command popup to diary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,3 +37,8 @@ logic and data handling while UI components live under `frontend/`.
 Offline Flet documentation resides in `docs/flet-docs`.
 Place any Langchain-related docs under `docs/langchain-docs`. The repository already includes documentation for `LangMem`.
 Update the Flet docs whenever the `flet` dependency version changes.
+
+## Diary Command Popup
+The diary view includes a popup triggered by typing a backslash. When
+modifying this feature add or update unit tests to ensure the popup shows,
+hides, and positions correctly. Update the README with any behavior changes.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ See the [Flet publish guide](https://flet.dev/docs/publish/) for signing and dis
 - Chat history context awareness
 - Persistent settings (KoboldCPP URL)
 - Simple diary to store notes
+- Backslash-triggered command popup in the diary view
 - User data is stored under the `storage/` folder
 
 ## Code Structure
@@ -88,6 +89,7 @@ Offline documentation for Flet lives under `docs/flet-docs` and can be consulted
 - Diary functionality, to let users write and save diary entries (Can be used later on as context for the LLM through Langchain)
   - [x] Create diary button in navigation drawer which leads into a diary view
   - [x] Give diary view a text editor style to write diary entries
+  - [ ] Command popup to trigger LLM self-reflection questions
 
 - Frontend general
   - [ ] Improve styling

--- a/src/frontend/diary_view.py
+++ b/src/frontend/diary_view.py
@@ -5,6 +5,13 @@ class DiaryView(ft.Column):
     """Full-screen diary entry editor view."""
 
     def __init__(self):
+        self.command_popup = ft.Container(
+            content=ft.Column([ft.Text("Command 1"), ft.Text("Command 2")]),
+            bgcolor=ft.Colors.WHITE,
+            border=ft.border.all(1, ft.Colors.OUTLINE),
+            padding=10,
+            visible=False,
+        )
         self.editor = ft.TextField(
             multiline=True,
             expand=True,
@@ -13,12 +20,20 @@ class DiaryView(ft.Column):
             text_vertical_align=ft.VerticalAlignment.START,
             autofocus=True,
             border=ft.InputBorder.NONE,
+            on_change=self._on_editor_change,
         )
         super().__init__(
-            [self.editor],
+            [self.editor, self.command_popup],
             visible=False,
             expand=True,
         )
+
+    def _on_editor_change(self, e):
+        """Show command popup when a backslash is typed."""
+        if self.editor.value.endswith("\\"):
+            self.command_popup.visible = True
+        else:
+            self.command_popup.visible = False
 
     def get_text(self) -> str:
         return self.editor.value

--- a/src/frontend/diary_view.py
+++ b/src/frontend/diary_view.py
@@ -28,12 +28,12 @@ class DiaryView(ft.Column):
             expand=True,
         )
 
-    def _on_editor_change(self, e):
-        """Show command popup when a backslash is typed."""
-        if self.editor.value.endswith("\\"):
-            self.command_popup.visible = True
-        else:
-            self.command_popup.visible = False
+    def _on_editor_change(self, e: ft.ControlEvent) -> None:
+        """Toggle command popup visibility when a backslash is typed."""
+        last_char = e.control.value[-1:] if e.control.value else ""
+        self.command_popup.visible = last_char == "\\"
+        if self.page:
+            self.update()
 
     def get_text(self) -> str:
         return self.editor.value

--- a/src/frontend/diary_view.py
+++ b/src/frontend/diary_view.py
@@ -4,6 +4,8 @@ import flet as ft
 class DiaryView(ft.Column):
     """Full-screen diary entry editor view."""
 
+    LINE_HEIGHT: int = 24
+
     def __init__(self):
         self.command_popup = ft.Container(
             content=ft.Column([ft.Text("Command 1"), ft.Text("Command 2")]),
@@ -11,6 +13,8 @@ class DiaryView(ft.Column):
             border=ft.border.all(1, ft.Colors.OUTLINE),
             padding=10,
             visible=False,
+            left=0,
+            top=0,
         )
         self.editor = ft.TextField(
             multiline=True,
@@ -22,8 +26,9 @@ class DiaryView(ft.Column):
             border=ft.InputBorder.NONE,
             on_change=self._on_editor_change,
         )
+        self.stack = ft.Stack([self.editor, self.command_popup], expand=True)
         super().__init__(
-            [self.editor, self.command_popup],
+            [self.stack],
             visible=False,
             expand=True,
         )
@@ -32,6 +37,10 @@ class DiaryView(ft.Column):
         """Toggle command popup visibility when a backslash is typed."""
         last_char = e.control.value[-1:] if e.control.value else ""
         self.command_popup.visible = last_char == "\\"
+        if self.command_popup.visible:
+            line_count = len(e.control.value.splitlines())
+            self.command_popup.top = line_count * self.LINE_HEIGHT
+            self.command_popup.left = 0
         if self.page:
             self.update()
 

--- a/tests/test_diary_view.py
+++ b/tests/test_diary_view.py
@@ -5,11 +5,16 @@ sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))
 from frontend.diary_view import DiaryView
 
 
+class DummyEvent:
+    def __init__(self, control):
+        self.control = control
+
+
 def test_popup_visibility_on_backslash():
     view = DiaryView()
     view.editor.value = 'Hello\\'
-    view._on_editor_change(None)
+    view._on_editor_change(DummyEvent(view.editor))
     assert view.command_popup.visible is True
     view.editor.value = 'Hello'
-    view._on_editor_change(None)
+    view._on_editor_change(DummyEvent(view.editor))
     assert view.command_popup.visible is False

--- a/tests/test_diary_view.py
+++ b/tests/test_diary_view.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))
+
+from frontend.diary_view import DiaryView
+
+
+def test_popup_visibility_on_backslash():
+    view = DiaryView()
+    view.editor.value = 'Hello\\'
+    view._on_editor_change(None)
+    assert view.command_popup.visible is True
+    view.editor.value = 'Hello'
+    view._on_editor_change(None)
+    assert view.command_popup.visible is False

--- a/tests/test_diary_view.py
+++ b/tests/test_diary_view.py
@@ -18,3 +18,11 @@ def test_popup_visibility_on_backslash():
     view.editor.value = 'Hello'
     view._on_editor_change(DummyEvent(view.editor))
     assert view.command_popup.visible is False
+
+
+def test_popup_position_below_line():
+    view = DiaryView()
+    view.editor.value = 'First line\nSecond\\'
+    view._on_editor_change(DummyEvent(view.editor))
+    expected_top = len(view.editor.value.splitlines()) * DiaryView.LINE_HEIGHT
+    assert view.command_popup.top == expected_top


### PR DESCRIPTION
## Summary
- show a popup with sample commands in `DiaryView`
- toggle popup visibility when a backslash is typed
- test popup visibility logic

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ff50d70ac8320ab48786094f4cd0e