### PR TITLE
Add diary reflection question command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ See the [Flet publish guide](https://flet.dev/docs/publish/) for signing and dis
 - Persistent settings (KoboldCPP URL)
 - Simple diary to store notes
 - Backslash-triggered command popup in the diary view
+- Self-reflection question command powered by KoboldCPP
 - User data is stored under the `storage/` folder
 
 ## Code Structure

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ See the [Flet publish guide](https://flet.dev/docs/publish/) for signing and dis
 - Persistent settings (KoboldCPP URL)
 - Simple diary to store notes
 - Backslash-triggered command popup in the diary view
+- The triggering backslash is removed after executing a command
 - Self-reflection question command powered by KoboldCPP
 - User data is stored under the `storage/` folder
 

--- a/src/backend/backend.py
+++ b/src/backend/backend.py
@@ -62,3 +62,34 @@ class ChatBackend:
                     break
         # Return the full assistant response after streaming ends
         return bot_reply
+
+    def generate_diary_question(
+        self,
+        diary_text: str,
+        max_tokens: int = 50,
+        temperature: float = 0.7,
+    ) -> str:
+        """Generate a self-reflection question for a diary entry."""
+        prompt = (
+            "Stelle eine kurze, selbstreflektierende Frage basierend auf folgendem Tagebucheintrag:\n"
+            f"{diary_text}"
+        )
+        try:
+            response = requests.post(
+                self.api_url,
+                json={
+                    "model": "kobold_chat_v2",
+                    "messages": [
+                        {"role": "system", "content": self.DEFAULT_SYSTEM_PROMPT},
+                        {"role": "user", "content": prompt},
+                    ],
+                    "max_tokens": max_tokens,
+                    "temperature": temperature,
+                },
+                timeout=120,
+            )
+            response.raise_for_status()
+            data = response.json()
+            return data["choices"][0]["message"]["content"].strip()
+        except Exception as ex:  # pragma: no cover - network errors
+            return f"[error connecting to KoboldCPP: {ex}]"

--- a/src/frontend/app.py
+++ b/src/frontend/app.py
@@ -119,7 +119,7 @@ class FletChatApp:
 
         settings_view = SettingsView(self.settings, save_settings_click)
 
-        diary_view = DiaryView()
+        diary_view = DiaryView(self.backend.generate_diary_question)
 
         def join_chat_click(e):
             """Validate the user name and broadcast the join event."""

--- a/src/frontend/diary_view.py
+++ b/src/frontend/diary_view.py
@@ -54,6 +54,8 @@ class DiaryView(ft.Column):
         if not self.question_callback:
             return
         question = self.question_callback(self.editor.value)
+        if self.editor.value.endswith("\\"):
+            self.editor.value = self.editor.value[:-1]
         if self.editor.value and not self.editor.value.endswith("\n"):
             self.editor.value += "\n"
         self.editor.value += question

--- a/src/frontend/diary_view.py
+++ b/src/frontend/diary_view.py
@@ -1,3 +1,5 @@
+from typing import Callable, Optional
+
 import flet as ft
 
 
@@ -6,9 +8,12 @@ class DiaryView(ft.Column):
 
     LINE_HEIGHT: int = 24
 
-    def __init__(self):
+    def __init__(self, question_callback: Optional[Callable[[str], str]] = None):
+        self.question_callback = question_callback
         self.command_popup = ft.Container(
-            content=ft.Column([ft.Text("Command 1"), ft.Text("Command 2")]),
+            content=ft.Column(
+                [ft.TextButton("Self-reflection question", on_click=self._insert_question)]
+            ),
             bgcolor=ft.Colors.WHITE,
             border=ft.border.all(1, ft.Colors.OUTLINE),
             padding=10,
@@ -41,6 +46,18 @@ class DiaryView(ft.Column):
             line_count = len(e.control.value.splitlines())
             self.command_popup.top = line_count * self.LINE_HEIGHT
             self.command_popup.left = 0
+        if self.page:
+            self.update()
+
+    def _insert_question(self, e: ft.ControlEvent) -> None:
+        """Insert a generated question below the current diary text."""
+        if not self.question_callback:
+            return
+        question = self.question_callback(self.editor.value)
+        if self.editor.value and not self.editor.value.endswith("\n"):
+            self.editor.value += "\n"
+        self.editor.value += question
+        self.command_popup.visible = False
         if self.page:
             self.update()
 

--- a/tests/test_diary_view.py
+++ b/tests/test_diary_view.py
@@ -40,3 +40,13 @@ def test_insert_question_appends_text():
     view._insert_question(None)
     assert called == ["Today was good"]
     assert view.editor.value.endswith("What do you feel right now?")
+
+
+def test_insert_question_removes_backslash():
+    def callback(_: str) -> str:
+        return "Question?"
+
+    view = DiaryView(callback)
+    view.editor.value = "Entry\\"
+    view._insert_question(None)
+    assert "\\" not in view.editor.value

--- a/tests/test_diary_view.py
+++ b/tests/test_diary_view.py
@@ -26,3 +26,17 @@ def test_popup_position_below_line():
     view._on_editor_change(DummyEvent(view.editor))
     expected_top = len(view.editor.value.splitlines()) * DiaryView.LINE_HEIGHT
     assert view.command_popup.top == expected_top
+
+
+def test_insert_question_appends_text():
+    called = []
+
+    def callback(text: str) -> str:
+        called.append(text)
+        return "What do you feel right now?"
+
+    view = DiaryView(callback)
+    view.editor.value = "Today was good"
+    view._insert_question(None)
+    assert called == ["Today was good"]
+    assert view.editor.value.endswith("What do you feel right now?")


### PR DESCRIPTION
## Summary
- add an API method to generate reflection questions
- add self-reflection command to diary popup
- wire backend method into app
- document new diary command in README
- test question insertion in diary view

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68500135cf9c8320acbc7ca62a987c92