### PR TITLE
Remove login popup and move user settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ After installing the requirements, you can run the app by executing the followin
 flet run
 ```
 
-Start your KoboldCPP server first. On initial launch you will be prompted for your name. Open the settings view to change the API URL if it differs from the default. The URL is persisted in `storage/settings.json` and diary entries are stored in `storage/diary.db`.
+Start your KoboldCPP server first. Open the settings view to enter your name above the KoboldCPP URL and adjust the API endpoint if needed. The URL is persisted in `storage/settings.json` and diary entries are stored in `storage/diary.db`.
 
 ## Building Distributables
 
@@ -101,7 +101,6 @@ Offline documentation for Flet lives under `docs/flet-docs` and can be consulted
 - Frontend general
   - [ ] Improve styling
 
-- User functionality (Needs way more thoughts and planning, e. g. how to handle multiple users, how and where to store user data, etc.)
-  - [x] User name input on first launch
-  - [ ] Change User welcome name inpput on first launch (Its temporary and not saved). Instead i would like to have a user managment system where users can log in and out. Last user is remembered.
+- User functionality
+  - [x] User name stored in settings
 

--- a/src/backend/settings_manager.py
+++ b/src/backend/settings_manager.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, asdict
+from dataclasses import asdict, dataclass
 import json
 import os
 
@@ -20,6 +20,8 @@ class AppSettings:
     diary_prompt: str = ChatBackend.DEFAULT_DIARY_PROMPT
     diary_temperature: float = 0.7
     diary_max_tokens: int = 50
+    user_name: str = "User"
+    avatar_color: str = "blue"
 
 
 def load_settings(path: str = SETTINGS_FILE) -> AppSettings:
@@ -31,7 +33,9 @@ def load_settings(path: str = SETTINGS_FILE) -> AppSettings:
         try:
             with open(path, "r", encoding="utf-8") as f:
                 data = json.load(f)
-            return AppSettings(**data)
+            defaults = asdict(AppSettings())
+            defaults.update(data)
+            return AppSettings(**defaults)
         except Exception:
             pass
     return AppSettings()

--- a/src/frontend/app.py
+++ b/src/frontend/app.py
@@ -72,20 +72,7 @@ class FletChatApp:
         page.horizontal_alignment = ft.CrossAxisAlignment.STRETCH
         page.title = "Flet + KoboldCPP: Voller Chatkontext"
 
-        join_user_name = ft.TextField(
-            label="Enter your name to join the chat",
-            autofocus=True,
-            on_submit=lambda e: join_chat_click(e),
-        )
-        welcome_dlg = ft.AlertDialog(
-            open=True,
-            modal=True,
-            title=ft.Text("Welcome!"),
-            content=ft.Column([join_user_name], width=300, height=70, tight=True),
-            actions=[ft.ElevatedButton(text="Join chat", on_click=lambda e: join_chat_click(e))],
-            actions_alignment=ft.MainAxisAlignment.END,
-        )
-        page.overlay.append(welcome_dlg)
+
 
         def send_message_click(e):
             """Send the current input box content to all clients and the LLM."""
@@ -93,10 +80,9 @@ class FletChatApp:
             if not text:
                 return
 
-            user_name = page.session.get("user_name") or "Unknown"
+            user_name = self.settings.user_name
 
-            page.pubsub.send_all(Message(user_name=user_name, text=text, message_type="chat_message"))
-
+            chat_view.add_message(Message(user_name=user_name, text=text, message_type="chat_message"))
             self.backend.add_user_message(text)
 
             chat_view.new_message.value = ""
@@ -106,10 +92,10 @@ class FletChatApp:
             bot_reply = self.backend.generate_reply()
             self.backend.add_assistant_message(bot_reply)
 
-            page.pubsub.send_all(Message(user_name="Bot", text=bot_reply, message_type="chat_message"))
+            chat_view.add_message(Message(user_name="Bot", text=bot_reply, message_type="chat_message"))
             page.update()
 
-        chat_view = ChatView(self.backend, send_message_click)
+        chat_view = ChatView(self.backend, send_message_click, self.settings)
 
         def save_diary_click(e):
             """Persist a new or edited diary entry."""
@@ -138,6 +124,8 @@ class FletChatApp:
             self.backend.diary_prompt = settings_view.get_diary_prompt()
             self.backend.diary_temperature = settings_view.get_diary_temperature()
             self.backend.diary_max_tokens = settings_view.get_diary_max_tokens()
+            self.settings.user_name = settings_view.get_user_name()
+            self.settings.avatar_color = settings_view.get_avatar_color()
             self.settings.api_url = settings_view.get_url()
             self.settings.system_prompt = settings_view.get_system_prompt()
             self.settings.temperature = settings_view.get_temperature()
@@ -146,6 +134,7 @@ class FletChatApp:
             self.settings.diary_prompt = settings_view.get_diary_prompt()
             self.settings.diary_temperature = settings_view.get_diary_temperature()
             self.settings.diary_max_tokens = settings_view.get_diary_max_tokens()
+            chat_view.set_user(self.settings.user_name)
             save_settings(self.settings)
             page.snack_bar = ft.SnackBar(ft.Text("Settings saved"), open=True)
             page.update()
@@ -164,31 +153,6 @@ class FletChatApp:
 
         saved_diary_view = SavedDiaryView(open_saved_entry, delete_saved_entry)
 
-        def join_chat_click(e):
-            """Validate the user name and broadcast the join event."""
-            if not join_user_name.value:
-                join_user_name.error_text = "Name cannot be blank!"
-                join_user_name.update()
-                return
-
-            page.session.set("user_name", join_user_name.value)
-            welcome_dlg.open = False
-            chat_view.set_user(join_user_name.value)
-            page.pubsub.send_all(
-                Message(
-                    user_name=join_user_name.value,
-                    text=f"{join_user_name.value} has joined the chat.",
-                    message_type="login_message",
-                )
-            )
-            page.update()
-
-        def on_message(message: Message):
-            """Receive published messages and show them in the chat view."""
-            chat_view.add_message(message)
-            page.update()
-
-        page.pubsub.subscribe(on_message)
 
         def show_chat():
             """Display the chat view and hide the settings view."""
@@ -211,6 +175,8 @@ class FletChatApp:
             settings_view.set_diary_prompt(self.backend.diary_prompt)
             settings_view.set_diary_temperature(self.backend.diary_temperature)
             settings_view.set_diary_max_tokens(self.backend.diary_max_tokens)
+            settings_view.set_user_name(self.settings.user_name)
+            settings_view.set_avatar_color(self.settings.avatar_color)
             chat_view.visible = False
             diary_view.visible = False
             saved_diary_view.visible = False

--- a/src/frontend/chat_message.py
+++ b/src/frontend/chat_message.py
@@ -6,7 +6,7 @@ from backend import Message
 class ChatMessage(ft.Row):
     """UI widget representing a single chat message."""
 
-    def __init__(self, message: Message):
+    def __init__(self, message: Message, avatar_color: str):
         """Create visual representation of a message for the chat list."""
         super().__init__()
         self.vertical_alignment = ft.CrossAxisAlignment.START
@@ -14,7 +14,7 @@ class ChatMessage(ft.Row):
             ft.CircleAvatar(
                 content=ft.Text(self._get_initials(message.user_name)),
                 color=ft.Colors.WHITE,
-                bgcolor=self._get_avatar_color(message.user_name),
+                bgcolor=avatar_color,
             ),
             ft.Column(
                 [
@@ -31,22 +31,3 @@ class ChatMessage(ft.Row):
         """Return first letter of the user name for the avatar."""
         return user_name[:1].upper() if user_name else "?"
 
-    @staticmethod
-    def _get_avatar_color(user_name: str):
-        """Deterministically pick a color based on the user name."""
-        colors_lookup = [
-            ft.Colors.AMBER,
-            ft.Colors.BLUE,
-            ft.Colors.BROWN,
-            ft.Colors.CYAN,
-            ft.Colors.GREEN,
-            ft.Colors.INDIGO,
-            ft.Colors.LIME,
-            ft.Colors.ORANGE,
-            ft.Colors.PINK,
-            ft.Colors.PURPLE,
-            ft.Colors.RED,
-            ft.Colors.TEAL,
-            ft.Colors.YELLOW,
-        ]
-        return colors_lookup[hash(user_name) % len(colors_lookup)]

--- a/src/frontend/chat_view.py
+++ b/src/frontend/chat_view.py
@@ -1,6 +1,6 @@
 import flet as ft
 
-from backend import ChatBackend, Message
+from backend import AppSettings, ChatBackend, Message
 
 from .chat_message import ChatMessage
 
@@ -8,9 +8,10 @@ from .chat_message import ChatMessage
 class ChatView(ft.Column):
     """Main chat view containing the message list and input field."""
 
-    def __init__(self, backend: ChatBackend, send_message_callback):
+    def __init__(self, backend: ChatBackend, send_message_callback, settings: AppSettings):
         """Initialize widgets and wire up the send message callback."""
         self.backend = backend
+        self.settings = settings
         self.chat = ft.ListView(expand=True, spacing=10, auto_scroll=True)
         self.new_message = ft.TextField(
             hint_text="Write a message...",
@@ -45,6 +46,7 @@ class ChatView(ft.Column):
             expand=True,
             visible=True,
         )
+        self.set_user(self.settings.user_name)
 
     def set_user(self, user_name: str) -> None:
         """Update message prefix with the current user name."""
@@ -52,14 +54,13 @@ class ChatView(ft.Column):
 
     def add_message(self, message: Message) -> None:
         """Append a message to the chat list."""
-        # Display login events differently from regular chat messages.
-        if message.message_type == "chat_message":
-            control = ChatMessage(message)
-        elif message.message_type == "login_message":
-            control = ft.Text(
-                message.text, italic=True, color=ft.Colors.BLACK45, size=12
-            )
-        else:
+        if message.message_type != "chat_message":
             return
+        color = (
+            self.settings.avatar_color
+            if message.user_name != "Bot"
+            else ft.Colors.GREY_300
+        )
+        control = ChatMessage(message, color)
         self.chat.controls.append(control)
 

--- a/src/frontend/settings_view.py
+++ b/src/frontend/settings_view.py
@@ -9,6 +9,25 @@ class SettingsView(ft.Column):
     def __init__(self, settings: AppSettings, save_callback) -> None:
         """Create settings form."""
         self.settings = settings
+        self.user_field = ft.TextField(
+            label="User Name",
+            value=self.settings.user_name,
+            expand=True,
+        )
+        self.color_dropdown = ft.Dropdown(
+            label="Avatar Color",
+            options=[
+                ft.dropdown.Option("amber"),
+                ft.dropdown.Option("blue"),
+                ft.dropdown.Option("cyan"),
+                ft.dropdown.Option("green"),
+                ft.dropdown.Option("orange"),
+                ft.dropdown.Option("pink"),
+                ft.dropdown.Option("purple"),
+                ft.dropdown.Option("red"),
+            ],
+            value=self.settings.avatar_color,
+        )
         self.url_field = ft.TextField(
             label="KoboldCPP URL",
             value=self.settings.api_url,
@@ -79,7 +98,13 @@ class SettingsView(ft.Column):
         )
 
         list_view = ft.ListView(
-            controls=[self.url_field, chat_tile, diary_tile],
+            controls=[
+                self.user_field,
+                self.color_dropdown,
+                self.url_field,
+                chat_tile,
+                diary_tile,
+            ],
             expand=True,
             spacing=10,
         )
@@ -159,4 +184,20 @@ class SettingsView(ft.Column):
     def set_diary_max_tokens(self, value: int) -> None:
         """Update diary max tokens field."""
         self.diary_tokens_field.value = str(value)
+
+    def get_user_name(self) -> str:
+        """Return the configured user name."""
+        return self.user_field.value
+
+    def set_user_name(self, name: str) -> None:
+        """Update the user name field."""
+        self.user_field.value = name
+
+    def get_avatar_color(self) -> str:
+        """Return the selected avatar color."""
+        return self.color_dropdown.value or "blue"
+
+    def set_avatar_color(self, color: str) -> None:
+        """Update the avatar color dropdown."""
+        self.color_dropdown.value = color
 

--- a/tests/test_chat_message.py
+++ b/tests/test_chat_message.py
@@ -3,6 +3,7 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))
 
 from frontend.chat_message import ChatMessage
+from backend import Message
 
 
 def test_get_initials():
@@ -10,5 +11,7 @@ def test_get_initials():
     assert ChatMessage._get_initials('') == '?'
 
 
-def test_avatar_color_deterministic():
-    assert ChatMessage._get_avatar_color('Alice') == ChatMessage._get_avatar_color('Alice')
+def test_avatar_color_applied():
+    msg = Message(user_name='Alice', text='hi', message_type='chat_message')
+    cm = ChatMessage(msg, 'red')
+    assert cm.controls[0].bgcolor == 'red'

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -17,6 +17,8 @@ def test_load_settings_defaults(tmp_path):
     assert settings.diary_prompt == ChatBackend.DEFAULT_DIARY_PROMPT
     assert settings.diary_temperature == 0.7
     assert settings.diary_max_tokens == 50
+    assert settings.user_name == "User"
+    assert settings.avatar_color == "blue"
 
 
 def test_save_and_load_settings(tmp_path):
@@ -30,6 +32,8 @@ def test_save_and_load_settings(tmp_path):
         diary_prompt='dp',
         diary_temperature=0.6,
         diary_max_tokens=75,
+        user_name="Alice",
+        avatar_color="red",
     )
     save_settings(settings, path)
     loaded = load_settings(path)


### PR DESCRIPTION
## Summary
- remove welcome dialog and multi-user login code
- store user name and avatar color in settings
- allow customizing user and avatar color via Settings view
- update ChatView and ChatMessage to use new user settings
- document new behavior in README

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851839c328883209b445e04efeef4fa