### PR TITLE
Add LangMem memory agent

### DIFF
--- a/src/backend/__init__.py
+++ b/src/backend/__init__.py
@@ -1,4 +1,5 @@
 from .backend import ChatBackend
+from .memory_agent import LangMemAgent
 from .models import Message
 from .settings_manager import AppSettings, load_settings, save_settings
 from .diary_manager import (
@@ -20,4 +21,5 @@ __all__ = [
     "load_entries",
     "delete_entry",
     "update_entry",
+    "LangMemAgent",
 ]

--- a/src/backend/backend.py
+++ b/src/backend/backend.py
@@ -1,6 +1,8 @@
 import json
 import requests
 
+from .memory_agent import LangMemAgent
+
 
 class ChatBackend:
     """Simple backend handling chat history and LLM interaction."""
@@ -20,6 +22,7 @@ class ChatBackend:
         diary_prompt: str | None = None,
         diary_temperature: float = 0.7,
         diary_max_tokens: int = 50,
+        memory_agent: LangMemAgent | None = None,
     ) -> None:
         """Initialize backend with all LLM parameters."""
         self.api_url = api_url
@@ -30,6 +33,7 @@ class ChatBackend:
         self.diary_prompt = diary_prompt or self.DEFAULT_DIARY_PROMPT
         self.diary_temperature = diary_temperature
         self.diary_max_tokens = diary_max_tokens
+        self.memory_agent = memory_agent or LangMemAgent()
         # Seed conversation with a system prompt so the LLM knows how to behave
         self.chat_history = [
             {"role": "system", "content": self.system_prompt}
@@ -38,6 +42,7 @@ class ChatBackend:
     def add_user_message(self, text: str) -> None:
         """Append a user message to the in-memory history."""
         self.chat_history.append({"role": "user", "content": text})
+        self.memory_agent.save(text)
 
     def add_assistant_message(self, text: str) -> None:
         """Append an assistant message to the in-memory history."""

--- a/src/backend/memory_agent.py
+++ b/src/backend/memory_agent.py
@@ -1,0 +1,20 @@
+"""LangMem agent storing user memories using the hot path approach."""
+
+from __future__ import annotations
+
+from langgraph.store.memory import InMemoryStore
+from langmem import create_manage_memory_tool
+
+
+class LangMemAgent:
+    """Minimal wrapper around LangMem's manage_memory tool."""
+
+    def __init__(self, store: InMemoryStore | None = None) -> None:
+        self.store = store or InMemoryStore()
+        self._tool = create_manage_memory_tool(namespace=("memories",), store=self.store)
+
+    def save(self, text: str) -> None:
+        """Persist a new memory about the user."""
+        self._tool.invoke({"content": text})
+
+

--- a/tests/test_langmem_integration.py
+++ b/tests/test_langmem_integration.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))
+
+from backend import ChatBackend
+from backend.memory_agent import LangMemAgent
+
+
+class DummyAgent(LangMemAgent):
+    def __init__(self):
+        self.saved: list[str] = []
+
+    def save(self, text: str) -> None:  # type: ignore[override]
+        self.saved.append(text)
+
+
+def test_user_messages_saved():
+    mem = DummyAgent()
+    backend = ChatBackend('http://api', memory_agent=mem)
+    backend.add_user_message('hello')
+    assert mem.saved == ['hello']
+


### PR DESCRIPTION
## Summary
- integrate LangMem into the backend
- save user messages using a simple `LangMemAgent`
- export the new agent from the backend package
- test that user messages are recorded

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68596426d4208320985edc5925162834