### PR TITLE
Enable UI streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ See the [Flet publish guide](https://flet.dev/docs/publish/) for signing and dis
 - Configurable self-reflection prompts and parameters
 - View saved diary entries sorted by date
 - Tap a saved entry to reopen and edit it
- - Delete saved entries with a long press and confirmation popup
+- Delete saved entries with a long press and confirmation popup
 - User data is stored under the `storage/` folder
 
 ## Code Structure

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Offline documentation for Flet lives under `docs/flet-docs` and can be consulted
   - [ ] Let LLM regenerate last message
   - [ ] Save chat 
   - [ ] Long term memory via Langchain (`LangMem`)
-  - [ ] fix streaming messages, despite ```"stream": True``` in backend.py it does not work
+  - [x] fix streaming messages, despite ```"stream": True``` in backend.py it does not work
   - [ ] Read and print which model is available (```curl http://localhost:5001/v1/models``` gives a list of available models)
   - [ ] Markdown rendering
 

--- a/src/backend/backend.py
+++ b/src/backend/backend.py
@@ -43,17 +43,14 @@ class ChatBackend:
         """Append an assistant message to the in-memory history."""
         self.chat_history.append({"role": "assistant", "content": text})
 
-    def generate_reply(
+    def stream_reply(
         self,
         max_tokens: int | None = None,
         temperature: float | None = None,
-    ) -> str:
-        """Generate a reply using the entire chat history."""
+    ):
+        """Yield assistant reply tokens as they arrive from the API."""
         max_tokens = max_tokens if max_tokens is not None else self.max_tokens
         temperature = temperature if temperature is not None else self.temperature
-        # Send the accumulated conversation to the KoboldCPP API and stream back
-        # the assistant's response. Errors are swallowed and returned as a string
-        # so the UI can display them directly.
         try:
             response = requests.post(
                 self.api_url,
@@ -69,9 +66,9 @@ class ChatBackend:
             )
             response.raise_for_status()
         except Exception as ex:  # pragma: no cover - network errors
-            return f"[error connecting to KoboldCPP: {ex}]"
+            yield f"[error connecting to KoboldCPP: {ex}]"
+            return
 
-        bot_reply = ""
         for chunk in response.iter_lines(decode_unicode=True):
             if not chunk:
                 continue
@@ -83,11 +80,17 @@ class ChatBackend:
                     continue
                 delta = j["choices"][0]["delta"].get("content", "")
                 if delta:
-                    bot_reply += delta
+                    yield delta
                 if j["choices"][0].get("finish_reason") == "stop":
                     break
-        # Return the full assistant response after streaming ends
-        return bot_reply
+
+    def generate_reply(
+        self,
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+    ) -> str:
+        """Return the full assistant reply after streaming completes."""
+        return "".join(self.stream_reply(max_tokens=max_tokens, temperature=temperature))
 
     def generate_diary_question(
         self,

--- a/src/frontend/app.py
+++ b/src/frontend/app.py
@@ -89,11 +89,17 @@ class FletChatApp:
             chat_view.new_message.focus()
             page.update()
 
-            bot_reply = self.backend.generate_reply()
-            self.backend.add_assistant_message(bot_reply)
-
-            chat_view.add_message(Message(user_name="Bot", text=bot_reply, message_type="chat_message"))
+            bot_message = Message(user_name="Bot", text="", message_type="chat_message")
+            msg_control = chat_view.add_message(bot_message)
             page.update()
+
+            bot_reply = ""
+            for delta in self.backend.stream_reply():
+                bot_reply += delta
+                msg_control.text_control.value = bot_reply
+                page.update()
+
+            self.backend.add_assistant_message(bot_reply)
 
         chat_view = ChatView(self.backend, send_message_click, self.settings)
 

--- a/src/frontend/chat_message.py
+++ b/src/frontend/chat_message.py
@@ -11,6 +11,7 @@ class ChatMessage(ft.Row):
         super().__init__()
         self.vertical_alignment = ft.CrossAxisAlignment.START
         self.expand = True
+        self.text_control = ft.Text(message.text, selectable=True)
         self.controls = [
             ft.CircleAvatar(
                 content=ft.Text(self._get_initials(message.user_name)),
@@ -20,7 +21,7 @@ class ChatMessage(ft.Row):
             ft.Column(
                 [
                     ft.Text(message.user_name),
-                    ft.Text(message.text, selectable=True),
+                    self.text_control,
                 ],
                 tight=True,
                 spacing=5,

--- a/src/frontend/chat_view.py
+++ b/src/frontend/chat_view.py
@@ -52,10 +52,10 @@ class ChatView(ft.Column):
         """Update message prefix with the current user name."""
         self.new_message.prefix = ft.Text(f"{user_name}: ")
 
-    def add_message(self, message: Message) -> None:
-        """Append a message to the chat list."""
+    def add_message(self, message: Message) -> ChatMessage | None:
+        """Append a message to the chat list and return the UI control."""
         if message.message_type != "chat_message":
-            return
+            return None
         color = (
             self.settings.avatar_color
             if message.user_name != "Bot"
@@ -63,4 +63,4 @@ class ChatView(ft.Column):
         )
         control = ChatMessage(message, color)
         self.chat.controls.append(control)
-
+        return control

--- a/tests/test_stream_reply.py
+++ b/tests/test_stream_reply.py
@@ -1,0 +1,32 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))
+
+import requests
+from backend import ChatBackend
+
+
+def test_stream_reply_and_generate_reply(monkeypatch):
+    chunks = [
+        'data: {"choices":[{"delta":{"content":"Hel"}}]}',
+        'data: {"choices":[{"delta":{"content":"lo"},"finish_reason":"stop"}]}',
+    ]
+
+    def fake_post(url, json, timeout, stream):
+        class Resp:
+            def raise_for_status(self):
+                pass
+
+            def iter_lines(self, decode_unicode=False):
+                for line in chunks:
+                    yield line if decode_unicode else line.encode()
+        return Resp()
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    backend = ChatBackend("http://api")
+
+    result = "".join(backend.stream_reply())
+    assert result == "Hello"
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    assert backend.generate_reply() == "Hello"


### PR DESCRIPTION
## Summary
- stream tokens from API using `stream_reply`
- update chat view to display assistant reply incrementally
- expose text field for editing `ChatMessage`
- mark streaming TODO fixed
- test streaming reply generation

## Testing
- `pip install -e .[dev]`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ac4f40b78832085fb649756bcff02