### PR TITLE
Enable streaming for diary questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ See the [Flet publish guide](https://flet.dev/docs/publish/) for signing and dis
 - Simple diary stored in an SQLite database
 - Diary view bottom bar with command and save buttons
 - Self-reflection question command powered by KoboldCPP
+- Diary questions stream live as they are generated
 - Configurable self-reflection prompts and parameters
 - View saved diary entries sorted by date
 - Tap a saved entry to reopen and edit it

--- a/src/backend/backend.py
+++ b/src/backend/backend.py
@@ -92,19 +92,21 @@ class ChatBackend:
         """Return the full assistant reply after streaming completes."""
         return "".join(self.stream_reply(max_tokens=max_tokens, temperature=temperature))
 
-    def generate_diary_question(
+    def stream_diary_question(
         self,
         diary_text: str,
         prompt: str | None = None,
         max_tokens: int | None = None,
         temperature: float | None = None,
         system_prompt: str | None = None,
-    ) -> str:
-        """Generate a self-reflection question for a diary entry."""
+    ):
+        """Yield a diary self-reflection question token by token."""
+
         prompt_text = (prompt or self.diary_prompt) + f"{diary_text}"
         max_tokens = max_tokens if max_tokens is not None else self.diary_max_tokens
         temperature = temperature if temperature is not None else self.diary_temperature
         system_prompt = system_prompt or self.diary_system_prompt
+
         try:
             response = requests.post(
                 self.api_url,
@@ -116,11 +118,47 @@ class ChatBackend:
                     ],
                     "max_tokens": max_tokens,
                     "temperature": temperature,
+                    "stream": True,
                 },
                 timeout=120,
+                stream=True,
             )
             response.raise_for_status()
-            data = response.json()
-            return data["choices"][0]["message"]["content"].strip()
         except Exception as ex:  # pragma: no cover - network errors
-            return f"[error connecting to KoboldCPP: {ex}]"
+            yield f"[error connecting to KoboldCPP: {ex}]"
+            return
+
+        for chunk in response.iter_lines(decode_unicode=True):
+            if not chunk:
+                continue
+            if chunk.startswith("data:"):
+                json_str = chunk[len("data:"):].strip()
+                try:
+                    j = json.loads(json_str)
+                except json.JSONDecodeError:
+                    continue
+                delta = j["choices"][0]["delta"].get("content", "")
+                if delta:
+                    yield delta
+                if j["choices"][0].get("finish_reason") == "stop":
+                    break
+
+    def generate_diary_question(
+        self,
+        diary_text: str,
+        prompt: str | None = None,
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+        system_prompt: str | None = None,
+    ) -> str:
+        """Return the full diary question after streaming completes."""
+
+        return "".join(
+            self.stream_diary_question(
+                diary_text,
+                prompt=prompt,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                system_prompt=system_prompt,
+            )
+        )

--- a/src/frontend/app.py
+++ b/src/frontend/app.py
@@ -147,7 +147,7 @@ class FletChatApp:
         settings_view = SettingsView(self.settings, save_settings_click)
 
         diary_view = DiaryView(
-            self.backend.generate_diary_question,
+            self.backend.stream_diary_question,
             save_diary_click,
         )
 

--- a/src/frontend/diary_view.py
+++ b/src/frontend/diary_view.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional
+from typing import Callable, Iterable, Optional
 
 from backend import DiaryEntry
 
@@ -13,7 +13,7 @@ class DiaryView(ft.Column):
 
     def __init__(
         self,
-        question_callback: Optional[Callable[[str], str]] = None,
+        question_callback: Optional[Callable[[str], Iterable[str] | str]] = None,
         save_callback: Optional[Callable[[ft.ControlEvent], None]] = None,
     ) -> None:
         self.question_callback = question_callback
@@ -78,10 +78,27 @@ class DiaryView(ft.Column):
         """Insert a generated question below the current diary text."""
         if not self.question_callback:
             return
-        question = self.question_callback(self.editor.value)
+        result = self.question_callback(self.editor.value)
+
+        if isinstance(result, str) or not hasattr(result, "__iter__"):
+            question = str(result)
+            if self.editor.value and not self.editor.value.endswith("\n"):
+                self.editor.value += "\n"
+            self.editor.value += question
+            self.command_popup.visible = False
+            if self.page:
+                self.update()
+            return
+
         if self.editor.value and not self.editor.value.endswith("\n"):
             self.editor.value += "\n"
-        self.editor.value += question
+        prefix = self.editor.value
+        question = ""
+        for delta in result:
+            question += delta
+            self.editor.value = prefix + question
+            if self.page:
+                self.update()
         self.command_popup.visible = False
         if self.page:
             self.update()

--- a/tests/test_diary_backend.py
+++ b/tests/test_diary_backend.py
@@ -6,16 +6,24 @@ import requests
 from backend import ChatBackend
 
 
-def test_generate_diary_question_uses_settings(monkeypatch):
+def test_stream_diary_question_and_generate(monkeypatch):
+    chunks = [
+        'data: {"choices":[{"delta":{"content":"Hel"}}]}',
+        'data: {"choices":[{"delta":{"content":"lo"},"finish_reason":"stop"}]}',
+    ]
     captured = {}
 
-    def fake_post(url, json, timeout):
+    def fake_post(url, json, timeout, stream):
         captured.update(json)
+
         class Resp:
             def raise_for_status(self):
                 pass
-            def json(self):
-                return {"choices": [{"message": {"content": "ok"}}]}
+
+            def iter_lines(self, decode_unicode=False):
+                for line in chunks:
+                    yield line if decode_unicode else line.encode()
+
         return Resp()
 
     monkeypatch.setattr(requests, "post", fake_post)
@@ -26,8 +34,13 @@ def test_generate_diary_question_uses_settings(monkeypatch):
         diary_temperature=0.6,
         diary_max_tokens=12,
     )
-    backend.generate_diary_question("text")
+
+    result = "".join(backend.stream_diary_question("text"))
+    assert result == "Hello"
     assert captured["messages"][0]["content"] == "SYS"
     assert captured["messages"][1]["content"] == "PROMPT\ntext"
     assert captured["temperature"] == 0.6
     assert captured["max_tokens"] == 12
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    assert backend.generate_diary_question("text") == "Hello"

--- a/tests/test_diary_view.py
+++ b/tests/test_diary_view.py
@@ -22,9 +22,14 @@ def test_popup_position_constant():
 def test_insert_question_appends_text():
     called = []
 
-    def callback(text: str) -> str:
+    def callback(text: str):
         called.append(text)
-        return "What do you feel right now?"
+        yield "What "
+        yield "do "
+        yield "you "
+        yield "feel "
+        yield "right "
+        yield "now?"
 
     view = DiaryView(callback)
     view.editor.value = "Today was good"


### PR DESCRIPTION
## Summary
- add `stream_diary_question` to backend and use it from DiaryView
- update DiaryView to stream question text while inserting
- wire up new streaming method in the app
- adjust tests for diary backend and view
- mention streaming diary questions in README

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b03428e908320a0e2c8038fc0d716