### PR TITLE
Add diary summary command

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ See the [Flet publish guide](https://flet.dev/docs/publish/) for signing and dis
 - Simple diary stored in an SQLite database
 - Diary view bottom bar with command and save buttons
 - Self-reflection question command powered by KoboldCPP
+- Summarize previous diary entry command
 - Diary questions stream live as they are generated
 - Configurable self-reflection prompts and parameters
 - View saved diary entries sorted by date

--- a/src/backend/backend.py
+++ b/src/backend/backend.py
@@ -9,6 +9,9 @@ class ChatBackend:
     DEFAULT_DIARY_PROMPT = (
         "Stelle eine kurze, selbstreflektierende Frage basierend auf folgendem Tagebucheintrag:\n"
     )
+    DEFAULT_SUMMARY_PROMPT = (
+        "Fasse kurz den folgenden Tagebucheintrag zusammen:\n"
+    )
 
     def __init__(
         self,
@@ -20,6 +23,10 @@ class ChatBackend:
         diary_prompt: str | None = None,
         diary_temperature: float = 0.7,
         diary_max_tokens: int = 50,
+        summary_system_prompt: str | None = None,
+        summary_prompt: str | None = None,
+        summary_temperature: float = 0.5,
+        summary_max_tokens: int = 50,
     ) -> None:
         """Initialize backend with all LLM parameters."""
         self.api_url = api_url
@@ -30,6 +37,10 @@ class ChatBackend:
         self.diary_prompt = diary_prompt or self.DEFAULT_DIARY_PROMPT
         self.diary_temperature = diary_temperature
         self.diary_max_tokens = diary_max_tokens
+        self.summary_system_prompt = summary_system_prompt or self.DEFAULT_SYSTEM_PROMPT
+        self.summary_prompt = summary_prompt or self.DEFAULT_SUMMARY_PROMPT
+        self.summary_temperature = summary_temperature
+        self.summary_max_tokens = summary_max_tokens
         # Seed conversation with a system prompt so the LLM knows how to behave
         self.chat_history = [
             {"role": "system", "content": self.system_prompt}
@@ -155,6 +166,81 @@ class ChatBackend:
 
         return "".join(
             self.stream_diary_question(
+                diary_text,
+                prompt=prompt,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                system_prompt=system_prompt,
+            )
+        )
+
+    def stream_diary_summary(
+        self,
+        diary_text: str,
+        prompt: str | None = None,
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+        system_prompt: str | None = None,
+    ):
+        """Yield a summary of the given diary text token by token."""
+
+        prompt_text = (prompt or self.summary_prompt) + f"{diary_text}"
+        max_tokens = (
+            max_tokens if max_tokens is not None else self.summary_max_tokens
+        )
+        temperature = (
+            temperature if temperature is not None else self.summary_temperature
+        )
+        system_prompt = system_prompt or self.summary_system_prompt
+
+        try:
+            response = requests.post(
+                self.api_url,
+                json={
+                    "model": "kobold_chat_v2",
+                    "messages": [
+                        {"role": "system", "content": system_prompt},
+                        {"role": "user", "content": prompt_text},
+                    ],
+                    "max_tokens": max_tokens,
+                    "temperature": temperature,
+                    "stream": True,
+                },
+                timeout=120,
+                stream=True,
+            )
+            response.raise_for_status()
+        except Exception as ex:  # pragma: no cover - network errors
+            yield f"[error connecting to KoboldCPP: {ex}]"
+            return
+
+        for chunk in response.iter_lines(decode_unicode=True):
+            if not chunk:
+                continue
+            if chunk.startswith("data:"):
+                json_str = chunk[len("data:"):].strip()
+                try:
+                    j = json.loads(json_str)
+                except json.JSONDecodeError:
+                    continue
+                delta = j["choices"][0]["delta"].get("content", "")
+                if delta:
+                    yield delta
+                if j["choices"][0].get("finish_reason") == "stop":
+                    break
+
+    def generate_diary_summary(
+        self,
+        diary_text: str,
+        prompt: str | None = None,
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+        system_prompt: str | None = None,
+    ) -> str:
+        """Return the full diary summary after streaming completes."""
+
+        return "".join(
+            self.stream_diary_summary(
                 diary_text,
                 prompt=prompt,
                 max_tokens=max_tokens,

--- a/src/backend/settings_manager.py
+++ b/src/backend/settings_manager.py
@@ -20,6 +20,10 @@ class AppSettings:
     diary_prompt: str = ChatBackend.DEFAULT_DIARY_PROMPT
     diary_temperature: float = 0.7
     diary_max_tokens: int = 50
+    summary_system_prompt: str = ChatBackend.DEFAULT_SYSTEM_PROMPT
+    summary_prompt: str = ChatBackend.DEFAULT_SUMMARY_PROMPT
+    summary_temperature: float = 0.5
+    summary_max_tokens: int = 50
     user_name: str = "User"
     avatar_color: str = "blue"
 

--- a/src/frontend/app.py
+++ b/src/frontend/app.py
@@ -129,6 +129,12 @@ class FletChatApp:
             self.backend.diary_prompt = settings_view.get_diary_prompt()
             self.backend.diary_temperature = settings_view.get_diary_temperature()
             self.backend.diary_max_tokens = settings_view.get_diary_max_tokens()
+            self.backend.summary_system_prompt = (
+                settings_view.get_summary_system_prompt()
+            )
+            self.backend.summary_prompt = settings_view.get_summary_prompt()
+            self.backend.summary_temperature = settings_view.get_summary_temperature()
+            self.backend.summary_max_tokens = settings_view.get_summary_max_tokens()
             self.settings.user_name = settings_view.get_user_name()
             self.settings.avatar_color = settings_view.get_avatar_color()
             self.settings.api_url = settings_view.get_url()
@@ -139,6 +145,14 @@ class FletChatApp:
             self.settings.diary_prompt = settings_view.get_diary_prompt()
             self.settings.diary_temperature = settings_view.get_diary_temperature()
             self.settings.diary_max_tokens = settings_view.get_diary_max_tokens()
+            self.settings.summary_system_prompt = (
+                settings_view.get_summary_system_prompt()
+            )
+            self.settings.summary_prompt = settings_view.get_summary_prompt()
+            self.settings.summary_temperature = (
+                settings_view.get_summary_temperature()
+            )
+            self.settings.summary_max_tokens = settings_view.get_summary_max_tokens()
             chat_view.set_user(self.settings.user_name)
             save_settings(self.settings)
             page.snack_bar = ft.SnackBar(ft.Text("Settings saved"), open=True)
@@ -146,9 +160,24 @@ class FletChatApp:
 
         settings_view = SettingsView(self.settings, save_settings_click)
 
+        def summarize_previous(_: str):
+            entries = load_entries()
+            target: str | None = None
+            if diary_view.current_entry_id is not None:
+                for i, entry in enumerate(entries):
+                    if entry.id == diary_view.current_entry_id and i > 0:
+                        target = entries[i - 1].text
+                        break
+            elif entries:
+                target = entries[-1].text
+            if not target:
+                return ""
+            return self.backend.stream_diary_summary(target)
+
         diary_view = DiaryView(
             self.backend.stream_diary_question,
             save_diary_click,
+            summarize_previous,
         )
 
         def open_saved_entry(entry: DiaryEntry) -> None:
@@ -183,6 +212,14 @@ class FletChatApp:
             settings_view.set_diary_prompt(self.backend.diary_prompt)
             settings_view.set_diary_temperature(self.backend.diary_temperature)
             settings_view.set_diary_max_tokens(self.backend.diary_max_tokens)
+            settings_view.set_summary_system_prompt(
+                self.backend.summary_system_prompt
+            )
+            settings_view.set_summary_prompt(self.backend.summary_prompt)
+            settings_view.set_summary_temperature(
+                self.backend.summary_temperature
+            )
+            settings_view.set_summary_max_tokens(self.backend.summary_max_tokens)
             settings_view.set_user_name(self.settings.user_name)
             settings_view.set_avatar_color(self.settings.avatar_color)
             chat_view.visible = False

--- a/src/frontend/diary_view.py
+++ b/src/frontend/diary_view.py
@@ -15,14 +15,23 @@ class DiaryView(ft.Column):
         self,
         question_callback: Optional[Callable[[str], Iterable[str] | str]] = None,
         save_callback: Optional[Callable[[ft.ControlEvent], None]] = None,
+        summary_callback: Optional[Callable[[str], Iterable[str] | str]] = None,
     ) -> None:
         self.question_callback = question_callback
         self.save_callback = save_callback
+        self.summary_callback = summary_callback
         self.current_entry_id: int | None = None
         self.current_entry_timestamp: str | None = None
         self.command_popup = ft.Container(
             content=ft.Column(
-                [ft.TextButton("Self-reflection question", on_click=self._insert_question)]
+                [
+                    ft.TextButton(
+                        "Self-reflection question", on_click=self._insert_question
+                    ),
+                    ft.TextButton(
+                        "Summarize previous entry", on_click=self._insert_summary
+                    ),
+                ]
             ),
             bgcolor=ft.Colors.WHITE,
             border=ft.border.all(1, ft.Colors.OUTLINE),
@@ -97,6 +106,34 @@ class DiaryView(ft.Column):
         for delta in result:
             question += delta
             self.editor.value = prefix + question
+            if self.page:
+                self.update()
+        self.command_popup.visible = False
+        if self.page:
+            self.update()
+
+    def _insert_summary(self, e: ft.ControlEvent) -> None:
+        """Insert a summary above the current diary text."""
+        if not self.summary_callback:
+            return
+        result = self.summary_callback(self.editor.value)
+
+        if isinstance(result, str) or not hasattr(result, "__iter__"):
+            summary = str(result)
+            self.editor.value = (
+                summary + "\n" + self.editor.value if self.editor.value else summary
+            )
+            self.command_popup.visible = False
+            if self.page:
+                self.update()
+            return
+
+        summary = ""
+        for delta in result:
+            summary += delta
+            self.editor.value = (
+                summary + "\n" + self.editor.value if self.editor.value else summary
+            )
             if self.page:
                 self.update()
         self.command_popup.visible = False

--- a/src/frontend/settings_view.py
+++ b/src/frontend/settings_view.py
@@ -75,6 +75,30 @@ class SettingsView(ft.Column):
             value=str(self.settings.diary_max_tokens),
             width=150,
         )
+        self.summary_sys_field = ft.TextField(
+            label="Summary System Prompt",
+            multiline=True,
+            value=self.settings.summary_system_prompt,
+            expand=True,
+        )
+        self.summary_prompt_field = ft.TextField(
+            label="Summary Prompt",
+            multiline=True,
+            value=self.settings.summary_prompt,
+            expand=True,
+        )
+        self.summary_temp_slider = ft.Slider(
+            min=0.0,
+            max=1.0,
+            divisions=10,
+            value=self.settings.summary_temperature,
+            label="{value}",
+        )
+        self.summary_tokens_field = ft.TextField(
+            label="Summary Max Tokens",
+            value=str(self.settings.summary_max_tokens),
+            width=150,
+        )
 
         chat_tile = ft.ExpansionTile(
             title=ft.Text("Chat LLM settings"),
@@ -97,6 +121,17 @@ class SettingsView(ft.Column):
             ],
         )
 
+        summary_tile = ft.ExpansionTile(
+            title=ft.Text("Summary LLM settings"),
+            initially_expanded=False,
+            controls=[
+                self.summary_sys_field,
+                self.summary_prompt_field,
+                self.summary_temp_slider,
+                self.summary_tokens_field,
+            ],
+        )
+
         list_view = ft.ListView(
             controls=[
                 self.user_field,
@@ -104,6 +139,7 @@ class SettingsView(ft.Column):
                 self.url_field,
                 chat_tile,
                 diary_tile,
+                summary_tile,
             ],
             expand=True,
             spacing=10,
@@ -184,6 +220,41 @@ class SettingsView(ft.Column):
     def set_diary_max_tokens(self, value: int) -> None:
         """Update diary max tokens field."""
         self.diary_tokens_field.value = str(value)
+
+    def get_summary_system_prompt(self) -> str:
+        """Return the summary system prompt."""
+        return self.summary_sys_field.value
+
+    def set_summary_system_prompt(self, text: str) -> None:
+        """Update the summary system prompt field."""
+        self.summary_sys_field.value = text
+
+    def get_summary_prompt(self) -> str:
+        """Return the summary prompt."""
+        return self.summary_prompt_field.value
+
+    def set_summary_prompt(self, text: str) -> None:
+        """Update the summary prompt field."""
+        self.summary_prompt_field.value = text
+
+    def get_summary_temperature(self) -> float:
+        """Return summary temperature."""
+        return float(self.summary_temp_slider.value)
+
+    def set_summary_temperature(self, value: float) -> None:
+        """Update summary temperature slider."""
+        self.summary_temp_slider.value = value
+
+    def get_summary_max_tokens(self) -> int:
+        """Return summary max tokens."""
+        try:
+            return int(self.summary_tokens_field.value)
+        except ValueError:
+            return 0
+
+    def set_summary_max_tokens(self, value: int) -> None:
+        """Update summary max tokens field."""
+        self.summary_tokens_field.value = str(value)
 
     def get_user_name(self) -> str:
         """Return the configured user name."""

--- a/tests/test_diary_backend.py
+++ b/tests/test_diary_backend.py
@@ -44,3 +44,43 @@ def test_stream_diary_question_and_generate(monkeypatch):
 
     monkeypatch.setattr(requests, "post", fake_post)
     assert backend.generate_diary_question("text") == "Hello"
+
+
+def test_stream_diary_summary_and_generate(monkeypatch):
+    chunks = [
+        'data: {"choices":[{"delta":{"content":"Sum"}}]}',
+        'data: {"choices":[{"delta":{"content":"mary"},"finish_reason":"stop"}]}',
+    ]
+    captured = {}
+
+    def fake_post(url, json, timeout, stream):
+        captured.update(json)
+
+        class Resp:
+            def raise_for_status(self):
+                pass
+
+            def iter_lines(self, decode_unicode=False):
+                for line in chunks:
+                    yield line if decode_unicode else line.encode()
+
+        return Resp()
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    backend = ChatBackend(
+        "http://api",
+        summary_system_prompt="SSP",
+        summary_prompt="SP\n",
+        summary_temperature=0.3,
+        summary_max_tokens=20,
+    )
+
+    result = "".join(backend.stream_diary_summary("text"))
+    assert result == "Summary"
+    assert captured["messages"][0]["content"] == "SSP"
+    assert captured["messages"][1]["content"] == "SP\ntext"
+    assert captured["temperature"] == 0.3
+    assert captured["max_tokens"] == 20
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    assert backend.generate_diary_summary("text") == "Summary"

--- a/tests/test_diary_view.py
+++ b/tests/test_diary_view.py
@@ -17,6 +17,7 @@ def test_popup_visibility_toggle():
 def test_popup_position_constant():
     view = DiaryView()
     assert view.command_popup.bottom == DiaryView.POPUP_BOTTOM
+    assert len(view.command_popup.content.controls) == 2
 
 
 def test_insert_question_appends_text():
@@ -36,6 +37,21 @@ def test_insert_question_appends_text():
     view._insert_question(None)
     assert called == ["Today was good"]
     assert view.editor.value.endswith("What do you feel right now?")
+
+
+def test_insert_summary_prepends_text():
+    called = []
+
+    def callback(text: str):
+        called.append(text)
+        yield "Sum"
+        yield "mary"
+
+    view = DiaryView(None, None, callback)
+    view.editor.value = "Entry"
+    view._insert_summary(None)
+    assert called == ["Entry"]
+    assert view.editor.value.startswith("Summary")
 
 
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -17,6 +17,10 @@ def test_load_settings_defaults(tmp_path):
     assert settings.diary_prompt == ChatBackend.DEFAULT_DIARY_PROMPT
     assert settings.diary_temperature == 0.7
     assert settings.diary_max_tokens == 50
+    assert settings.summary_system_prompt == ChatBackend.DEFAULT_SYSTEM_PROMPT
+    assert settings.summary_prompt == ChatBackend.DEFAULT_SUMMARY_PROMPT
+    assert settings.summary_temperature == 0.5
+    assert settings.summary_max_tokens == 50
     assert settings.user_name == "User"
     assert settings.avatar_color == "blue"
 
@@ -32,6 +36,10 @@ def test_save_and_load_settings(tmp_path):
         diary_prompt='dp',
         diary_temperature=0.6,
         diary_max_tokens=75,
+        summary_system_prompt='ssp',
+        summary_prompt='sp',
+        summary_temperature=0.4,
+        summary_max_tokens=25,
         user_name="Alice",
         avatar_color="red",
     )


### PR DESCRIPTION
## Summary
- implement diary summary prompt support in backend and settings
- add summary command to diary view UI and settings view
- update app logic to handle summary command
- extend tests for summary behavior and settings
- mention new feature in README

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c50849a94832085c2135ca37486bd